### PR TITLE
Replace 3 blink startup with transponder id

### DIFF
--- a/Arduino/TransmitterAttiny85v0.3/TransmitterAttiny85v0.3.ino
+++ b/Arduino/TransmitterAttiny85v0.3/TransmitterAttiny85v0.3.ino
@@ -143,12 +143,27 @@ void setup()
   pinMode(BUTTON_PIN, INPUT_PULLUP);
   PORTB |= (1 << BUTTON_PIN);    // enable pull-up resistor
 
-  for(int i=0; i < 3; i++){
+//Display Transponder ID in two sets of LED Flashes
+  for(int i=0; i < transponder_id/10; i++){ //Display MSB
     digitalWrite(STATUS_LED_PIN, HIGH);
-    delay(250);
+    delay(150);
     digitalWrite(STATUS_LED_PIN, LOW);
-    delay(250);
+    delay(150);
   }
+    //Display a single LED Flash to seperate the bits (helps distinguish ID 1 and ID 10)
+    delay(150);
+    digitalWrite(STATUS_LED_PIN, HIGH); 
+    delay(50);
+    digitalWrite(STATUS_LED_PIN, LOW);
+    delay(150);
+
+    for(int i=0; i < transponder_id%10; i++){ //Display LSB
+    digitalWrite(STATUS_LED_PIN, HIGH);
+    delay(150);
+    digitalWrite(STATUS_LED_PIN, LOW);
+    delay(150);
+  }
+
 #endif
 
 


### PR DESCRIPTION
replace the 3 blink startup with two sets of blinks (with a blink in between) to display the MSB and LSB of the transponder ID. for example 21 will be displayed as 2 quick blinks, a separating blink, and another blink.