### PR TITLE
Amorale/invalidate lap

### DIFF
--- a/web/app/adapters/race_session_adapter.rb
+++ b/web/app/adapters/race_session_adapter.rb
@@ -21,7 +21,7 @@ class RaceSessionAdapter
 
   def current_lap_for_pilot_by_token(token)
     pilot = self.get_pilot_by_token(token)
-    t = self.race_session.pilot_race_laps.where(pilot_id: pilot.id).order("lap_num DESC").first
+    t = self.race_session.pilot_race_laps_valid.where(pilot_id: pilot.id).order("lap_num DESC").first
 
     return t.lap_num+1 if t
     return 1
@@ -46,7 +46,7 @@ class RaceSessionAdapter
   end
 
   def current_lap_count
-    t = self.race_session.pilot_race_laps.order("lap_num DESC").first
+    t = self.race_session.pilot_race_laps_valid.order("lap_num DESC").first
     return t.lap_num if t
     return ""
   end
@@ -62,7 +62,7 @@ class RaceSessionAdapter
   def listing_standard_mode
     listing_data = Array.new
 
-    self.race_session.pilot_race_laps.order("lap_time ASC").group(:pilot_id).pluck(:pilot_id).each_with_index do |pilot_id,index|
+    self.race_session.pilot_race_laps_valid.order("lap_time ASC").group(:pilot_id).pluck(:pilot_id).each_with_index do |pilot_id,index|
       c_pilot = Pilot.where(id: pilot_id).first
       if c_pilot
         data = Hash.new
@@ -91,7 +91,7 @@ class RaceSessionAdapter
 
     listing_data = Array.new
 
-    self.race_session.pilot_race_laps.order("lap_num DESC,created_at ASC").group(:pilot_id).pluck(:pilot_id).each_with_index do |pilot_id,index|
+    self.race_session.pilot_race_laps_valid.order("lap_num DESC,created_at ASC").group(:pilot_id).pluck(:pilot_id).each_with_index do |pilot_id,index|
       c_pilot = Pilot.where(id: pilot_id).first
       if c_pilot
         data = Hash.new
@@ -121,7 +121,7 @@ class RaceSessionAdapter
     listing_data = Array.new
 
     pilot_time_sum_up = Hash.new
-    self.race_session.pilot_race_laps.order("created_at ASC").each do |lap|
+    self.race_session.pilot_race_laps_valid.order("created_at ASC").each do |lap|
       pilot = Pilot.find(lap.pilot_id)
 
       if !pilot_time_sum_up[lap.pilot_id]

--- a/web/app/assets/stylesheets/application.css.scss
+++ b/web/app/assets/stylesheets/application.css.scss
@@ -233,3 +233,8 @@ footer {
     margin-bottom: 0;
   }
 }
+
+.invalidatedlap {
+  color:red;
+  text-decoration:line-through;
+}

--- a/web/app/controllers/race_director_controller.rb
+++ b/web/app/controllers/race_director_controller.rb
@@ -9,6 +9,20 @@ class RaceDirectorController < ApplicationController
     @current_race_session_adapter = RaceSessionAdapter.new(@current_race_session) if @current_race_session
   end
 
+  def invalidate_lap
+    @pilot_race_lap = PilotRaceLap.find(params[:lapid])
+    @pilot_race_lap.mark_invalidated
+    flash[:notice] = t("messages.invalidated_successfully")
+    redirect_to request.referer
+  end
+
+  def undo_invalidate_lap
+    @pilot_race_lap = PilotRaceLap.find(params[:lapid])
+    @pilot_race_lap.undo_invalidated
+    flash[:notice] = t("messages.undo_invalidation_successfully")
+    redirect_to request.referer
+  end
+
   def lap_times
     @current_race_session = RaceSession::get_open_session
     @current_race_session_adapter = RaceSessionAdapter.new(@current_race_session) if @current_race_session

--- a/web/app/models/race_session.rb
+++ b/web/app/models/race_session.rb
@@ -75,24 +75,24 @@ class RaceSession < ActiveRecord::Base
   end
 
   def total_laps
-    self.pilot_race_laps.count
+    self.pilot_race_laps_valid.count
   end
 
   def fastest_lap_time
-    t = self.pilot_race_laps.order("lap_time ASC").first
+    t = self.pilot_race_laps_valid.order("lap_time ASC").first
     return t.lap_time if t
     return 0
   end
 
    def fastest_pilot
-    t = self.pilot_race_laps.order("lap_time ASC").first
+    t = self.pilot_race_laps_valid.order("lap_time ASC").first
     return t.pilot if t
     return nil
   end
 
   def average_lap_time
     begin
-      self.pilot_race_laps.sum(:lap_time) / self.pilot_race_laps.count
+      self.pilot_race_laps_valid.sum(:lap_time) / self.pilot_race_laps.count
     rescue Exception => ex
       return 0
     end
@@ -108,11 +108,11 @@ class RaceSession < ActiveRecord::Base
   end
 
   def lap_count_of_pilot(pilot)
-    return self.pilot_race_laps.where(pilot_id: pilot.id).count
+    return self.pilot_race_laps_valid.where(pilot_id: pilot.id).count
   end
 
   def fastest_lap_of_pilot(pilot)
-    return self.pilot_race_laps.where(pilot_id: pilot.id).order("lap_time ASC").first
+    return self.pilot_race_laps_valid.where(pilot_id: pilot.id).order("lap_time ASC").first
   end
 
   def last_lap_of_pilot(pilot)
@@ -120,12 +120,16 @@ class RaceSession < ActiveRecord::Base
   end
 
   def last_lap_of_pilot_is_lasted_tracked_time_of_race?(pilot)
-    t=  self.pilot_race_laps.where(pilot_id: pilot.id).order("id DESC").first
+    t=  self.pilot_race_laps_valid.where(pilot_id: pilot.id).order("id DESC").first
     return t.latest if t
     return false
   end
 
+  def pilot_race_laps_valid
+    return self.pilot_race_laps.where(invalidated: false)
+  end
+
   def avg_lap_time_of_pilot(pilot)
-    self.pilot_race_laps.where(pilot_id: pilot.id).sum(:lap_time) / self.pilot_race_laps.where(pilot_id: pilot.id).count
+    self.pilot_race_laps_valid.where(pilot_id: pilot.id).sum(:lap_time) / self.pilot_race_laps.where(pilot_id: pilot.id).count
   end
 end

--- a/web/app/views/pilots/laps.html.haml
+++ b/web/app/views/pilots/laps.html.haml
@@ -22,10 +22,11 @@
       %th Race
       %th Lap Number
       %th Lap Time
+      %th
 
   %tbody
     - @pilot.pilot_race_laps.order("id DESC").each do |lap_entry|
-      %tr
+      %tr{:class => ("invalidatedlap" if lap_entry.invalidated?)}
         %td
           %strong
             = lap_entry.created_at.to_s(:long)
@@ -38,3 +39,7 @@
         %td
           %strong
             = formated_lap_time(lap_entry.lap_time)
+        %td
+          %strong
+            = link_to_if(lap_entry.invalidated?, t('actions.undo_invalidate_lap'),{action: 'undo_invalidate_lap', controller: '/race_director', lapid:lap_entry.id},{class: 'btn btn-danger btn-large'}) do
+              = link_to(t('actions.invalidate_lap'),{action: 'invalidate_lap', controller: '/race_director', lapid:lap_entry.id},{class: 'btn btn-danger btn-large'})

--- a/web/config/locales/en.yml
+++ b/web/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
     delete: "delete"
     edit: "edit"
     deactivate_token: "remove token"
+    undo_invalidate_lap: "undo invalidation"
+    invalidate_lap: "invalidate"
   race_session:
     idle_time_in_seconds: Idle time (s)
     title: Title

--- a/web/config/locales/en.yml
+++ b/web/config/locales/en.yml
@@ -27,3 +27,6 @@ en:
   race_session:
     idle_time_in_seconds: Idle time (s)
     title: Title
+  messages:
+    invalidated_successfully: "Lap is marked as invalidated"
+    undo_invalidation_successfully: "Lap is marked as valid"

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
 
   get 'race_director' => 'race_director#index'
   get 'race_director/lap_times' => 'race_director#lap_times'
-
+  get 'race_director/invalidate_lap' => 'race_director#invalidate_lap'
+  get 'race_director/undo_invalidate_lap' => 'race_director#undo_invalidate_lap'
+  
   # You can have the root of your site routed with "root"
   get 'system' => 'system#index'
   get '/system/pilot' => 'system/pilot#index'

--- a/web/db/migrate/20160315232700_pilot_race_lap_invalidated.rb
+++ b/web/db/migrate/20160315232700_pilot_race_lap_invalidated.rb
@@ -1,0 +1,5 @@
+class PilotRaceLapInvalidated < ActiveRecord::Migration
+  def change
+    add_column :pilot_race_laps, :invalidated, :boolean, default:false, index: true
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160131102343) do
+ActiveRecord::Schema.define(version: 20160315232700) do
 
   create_table "config_values", force: :cascade do |t|
     t.string "name"
@@ -24,14 +24,15 @@ ActiveRecord::Schema.define(version: 20160131102343) do
   end
 
   create_table "pilot_race_laps", force: :cascade do |t|
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.integer  "pilot_id"
     t.integer  "lap_num"
     t.integer  "lap_time"
     t.integer  "race_session_id"
     t.datetime "deleted_at"
     t.boolean  "latest"
+    t.boolean  "invalidated",     default: false
   end
 
   add_index "pilot_race_laps", ["deleted_at"], name: "index_pilot_race_laps_on_deleted_at"


### PR DESCRIPTION
This changes allows users to mark laps as invalid and not counted as fastest lap during the race. 
It may be useful if a player misses a gate or similar situation.