### PR TITLE
fix lap_track response on standard mode

### DIFF
--- a/web/app/adapters/race_session_adapter.rb
+++ b/web/app/adapters/race_session_adapter.rb
@@ -160,6 +160,7 @@ class RaceSessionAdapter
     if self.race_session.mode == "standard"
       res = self.track_lap_time_standard_mode(transponder_token,delta_time_in_ms)
       RaceSessionEventAdapter.new(self,transponder_token).perform
+      return res
     elsif self.race_session.mode == "competition"
       res =  self.track_lap_time_competition_mode(transponder_token,delta_time_in_ms)
       RaceSessionEventAdapter.new(self,transponder_token).perform


### PR DESCRIPTION
Previously random/hash was returned on standard mode race. Now same json object as for competition mode